### PR TITLE
Fix incorrect-color issues

### DIFF
--- a/src/main/java/BasicColor.java
+++ b/src/main/java/BasicColor.java
@@ -71,6 +71,9 @@ public class BasicColor {
         colors.put(56, toCol(58, 142, 140));
         colors.put(57, toCol(86, 44, 62));
         colors.put(58, toCol(20, 180, 133));
+        colors.put(59, toCol(100, 100, 100));
+        colors.put(60, toCol(216, 175, 147));
+        colors.put(61, toCol(127, 167, 150));
     }
 
     private static BasicColor toCol(int r, int g, int b) {

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -43,7 +43,7 @@ public class Main {
                 for (int x = 0; x < 128; x++) {
                     for (int y = 0; y < 128; y++) {
                         byte input = data[x + y * 128];
-                        int colId = (input >>> 2) & 0b11111;
+                        int colId = (input >>> 2) & 0b111111;
                         byte shader = (byte) (input & 0b11);
 
                         BasicColor col = BasicColor.colors.get(colId);


### PR DESCRIPTION
This fixes an issue whereby the top bit of the color code was being discarded, so all color codes were being forced into the range of 0-31, resulting in images that had wrong colors and looked very odd.

Also, three new color codes have been added to maps since this application was first developed, and this adds those color codes.